### PR TITLE
Fixed typos in main.adoc 2.1. and 2.2.

### DIFF
--- a/docs/sources/main.adoc
+++ b/docs/sources/main.adoc
@@ -110,7 +110,7 @@ $ sudo dnf install qjackctl
 $ sudo yum install qjackctl
 ```
 
-.NixOs (if useing internal-synth, libjack2 must be installed via nix-env with its nix-env lib dir on LD_LIBRARY_PATH or alternatively loaded into a nix-shell)
+.NixOs (if using internal-synth, libjack2 must be installed via nix-env with its nix-env lib dir on LD_LIBRARY_PATH or alternatively loaded into a nix-shell)
 ```bash
 $ nix-env -i libjack2
 ```
@@ -144,7 +144,7 @@ $ lein deps
 TIP: `lein deps` is actually a redundant command as `lein repl` implicitly fetches Clojure dependencies before starting the REPL. It is only useful if you want to fetch the dependencies without starting the REPL.
 
 
-If you're running leiningen for the first time you should see whole bunch of text appearing to the screen, indicating that leiningen is downloading the Clojure dependencies needed to run Overtone. After this process, directories `target` and `native` should have been created, both of these directories can be safely omitted if you're planning on saving your code on for example github, and `target` can even be deleted at any time, by literally deleteing it or by running `lein clean` which by default deletes `target`, that will only be useful if you're trying to debug your program as `target` gets created every time you run leiningen to store various information irrelevant to us at this moment. But do keep `native` untouched as it stores the necessary files needed to run Supercollider from within Overtone.
+If you're running leiningen for the first time you should see a whole bunch of text appearing on the screen, indicating that leiningen is downloading the Clojure dependencies needed to run Overtone. After this process, directories `target` and `native` should have been created, both of these directories can be safely omitted if you're planning on saving your code on for example github, and `target` can even be deleted at any time, by literally deleteing it or by running `lein clean` which by default deletes `target`, that will only be useful if you're trying to debug your program as `target` gets created every time you run leiningen to store various information irrelevant to us at this moment. But do keep `native` untouched as it stores the necessary files needed to run Supercollider from within Overtone.
 
 Now let's start Clojure via `lein repl`
 


### PR DESCRIPTION
2.1. para 7

"useing" changed to "using"

2.2. para 9 

"see whole" changed to "see a whole"

"appearing to" changed to "appearing on"